### PR TITLE
Version 3.0.2 patch for LWJGL version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It aims to be fast and reliable for all Minecraft versions in a stateless manner
 
 ### [Install now!](#installation)
 
-#### ***[Fabric](/addons/fabric/README.md) and [Forge](/addons/forge/README.md) are now supported!***
+#### ***[Fabric](/src/fabric/README.md) and [Forge](/src/forge/README.md) are now supported!***
 
 **The launcher is safe to Log4j exploit since v2.2.0, if you are running an older please update or read the
 following issue for a temporary fix: [#52](https://github.com/mindstorm38/portablemc/issues/52).**

--- a/src/core/portablemc/__init__.py
+++ b/src/core/portablemc/__init__.py
@@ -59,9 +59,9 @@ __all__ = [
 
 
 LAUNCHER_NAME = "portablemc"
-LAUNCHER_VERSION = "3.0.0"
+LAUNCHER_VERSION = "3.0.2"
 LAUNCHER_AUTHORS = ["Théo Rozier <contact@theorozier.fr>", "Github contributors"]
-LAUNCHER_COPYRIGHT = "PortableMC  Copyright (C) 2021  Théo Rozier"
+LAUNCHER_COPYRIGHT = "PortableMC  Copyright (C) 2021-2022  Théo Rozier"
 LAUNCHER_URL = "https://github.com/mindstorm38/portablemc"
 
 

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "portablemc"
-version = "3.0.1"
+version = "3.0.2"
 description = "PortableMC is a module that provides both an API for development of your custom launcher and an executable script to run PortableMC CLI."
 authors = ["Théo Rozier <contact@theorozier.fr>"]
 license = "GPL-3.0-only"


### PR DESCRIPTION
This patch add support for LWJGL 3.3.1 for argument  `--lwjgl` and reworks how the metadata is edited.