### PR TITLE
Patch 4.0.3, better version manifest error

### DIFF
--- a/portablemc/__init__.py
+++ b/portablemc/__init__.py
@@ -7,7 +7,7 @@ public API, and therefore stable across minor and patch version bumps.
 """
 
 LAUNCHER_NAME = "portablemc"
-LAUNCHER_VERSION = "4.0.2"
+LAUNCHER_VERSION = "4.0.3"
 LAUNCHER_AUTHORS = ["Théo Rozier <contact@theorozier.fr>", "Github contributors"]
 LAUNCHER_COPYRIGHT = "PortableMC  Copyright (C) 2021-2023  Théo Rozier"
 LAUNCHER_URL = "https://github.com/mindstorm38/portablemc"

--- a/portablemc/cli/lang.py
+++ b/portablemc/cli/lang.py
@@ -118,6 +118,9 @@ lang = {
     "error.os": "An unexpected OS error happened:",
     "error.http": "Unhandled HTTP error happened:",
     "error.socket": "This operation requires an operational network, but a socket error happened:",
+    "error.socket.tip.version_manifest": "Version manifest may not be locally cached, try to run this command once with an operational network.",
+    "error.socket.tip.fabric_loader_version": "Fabric loader version must be specified if network is not operational.",
+    "error.socket.tip.quilt_loader_version": "Quilt loader version must be specified if network is not operational.",
     "error.cert": "Certificate verification failed, you can try installing 'certifi' package:",
     # Command search
     "search.type": "Type",

--- a/portablemc/cli/parse.py
+++ b/portablemc/cli/parse.py
@@ -26,6 +26,7 @@ class RootNs:
     context: Context
     version_manifest: VersionManifest
     auth_database: AuthDatabase
+    socket_error_tips: List[str]
 
 class SearchNs(RootNs):
     kind: str

--- a/portablemc/standard.py
+++ b/portablemc/standard.py
@@ -988,7 +988,7 @@ class Version:
 
     def _resolve_env(self, watcher: Watcher) -> Environment:
         """Step for computing correct environment to run the game as configured in this 
-        version's instance.²
+        version's instance.
         """
 
         assert self._assets_index_version is not None, "_resolve_assets() missing"
@@ -1452,6 +1452,12 @@ class VersionManifest:
 
         return self.data
 
+    def is_alias(self, version: str) -> bool:
+        """Basic function that returns true if the given version is an release or
+        snapshot alias.
+        """
+        return version in ("release", "snapshot")
+
     def filter_latest(self, version: str) -> Tuple[str, bool]:
         """Filter a version identifier if 'release' or 'snapshot' alias is used, then it's
         replaced by the full version identifier, like `1.19.3`.
@@ -1459,10 +1465,11 @@ class VersionManifest:
         :param version: The version id or alias.
         :return: A tuple containing the full version id and a boolean indicating if the
         given version identifier is an alias.
-        :raises HttpError: Underlying HTTP error if manifest could not be requested.
+        :raises HttpError: Underlying HTTP error if manifest could not be requested, only
+        possible when the given version is a known alias.
         """
 
-        if version in ("release", "snapshot"):
+        if self.is_alias(version):
             latest = self._ensure_data()["latest"].get(version)
             if latest is not None:
                 return latest, True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "portablemc"
-version = "4.0.2"
+version = "4.0.3"
 description = "PortableMC is a module that provides both an API for development of your custom launcher and an executable script to run PortableMC CLI."
 authors = ["Théo Rozier <contact@theorozier.fr>"]
 license = "GPL-3.0-only"


### PR DESCRIPTION
### Changes
- *CLI*: When socket errors happen with the `search` and `start` commands, the CLI provides tips to use it in offline-mode
- *CLI*: Fixed a concerning issue where the locally cached version manifest was not used for the `start` command.
