### PR TITLE
Version 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This launcher is compatible with the standard Minecraft directories.
   - [Setup environment](#setup-environment)
   - [Contributors](#contributors)
   - [Sponsors](#sponsors)
-- [API Documentation (v4.2) ⇗](https://github.com/mindstorm38/portablemc/blob/main/doc/API.md)
+- [API Documentation (v4.3) ⇗](https://github.com/mindstorm38/portablemc/blob/main/doc/API.md)
 
 ## Installation
 
@@ -107,13 +107,19 @@ needed by the version before launching it. If you provide no version, the latest
 is started, but you can specify a version to launch, or a version alias: `release`
 or `snapshot` for the latest version of their type.
 
-In addition to Mojang's vanilla versions, the launcher natively supports common mod
-loaders such as **Fabric**, **Forge**, **NeoForge** and **Quilt**. To start such versions,
-you can prefix the version with either `fabric:`, `forge:`, `neoforge:` or `quilt:` (or 
-`vanilla:` to explicitly choose a vanilla version).
-Depending on the mod loader, the version you put after the colon is different:
-- For Fabric and Quilt, you can directly specify the vanilla version, optionally followed
-  by `:<loader_version>`.
+In addition to Mojang's versions, the launcher natively supports common mod
+loaders: 
+[Fabric](https://fabricmc.net/), 
+[Forge](https://minecraftforge.net/), 
+[NeoForge](https://neoforged.net/), 
+[LegacyFabric](https://legacyfabric.net/) and 
+[Quilt](https://quiltmc.org/). 
+To start such versions, you can prefix the version with either `fabric:`, `forge:`, 
+`neoforge:`, `legacyfabric:` or `quilt:` (or `standard:` to explicitly choose a vanilla 
+version). Depending on the mod loader, the version you put after the colon is different:
+- For Fabric, LegacyFabric and Quilt, you can directly specify the vanilla version, 
+  optionally followed by `:<loader_version>`. Note that legacy fabric start 1.13.2
+  by default and does not support more recent version as it's not the goal.
 - For Forge and NeoForge, you can put either a vanilla game version, optionally followed
   by `-<loader_version>`. Forge also supports `-latest` and `-recommended`, but NeoForge
   will always take the latest loader.
@@ -260,6 +266,7 @@ you can instead search for many kinds of versions using the `-k` (`--kind`) argu
 - `forge`, show all recommended and latest Forge loader versions *(only 1.5.2 and 
   onward can be started)*.
 - `fabric`, show all available Fabric loader versions.
+- `legacyfabric`, show all available LegacyFabric loader versions.
 - `quilt`, show all available Quilt loader versions.
 
 The search string is optional, if not specified no filter is applied on the table shown.

--- a/doc/API.md
+++ b/doc/API.md
@@ -3,7 +3,7 @@ This page documents the public API of the launcher. This launcher
 library provides high flexibility for launching Minecraft in many
 environments.
 
-Documented version: `4.2`.
+Documented version: `4.3`.
 
 ## Table of contents
 - [File structure](#file-structure)

--- a/portablemc/__init__.py
+++ b/portablemc/__init__.py
@@ -7,7 +7,7 @@ public API, and therefore stable across minor and patch version bumps.
 """
 
 LAUNCHER_NAME = "portablemc"
-LAUNCHER_VERSION = "4.2.1"
+LAUNCHER_VERSION = "4.3.0"
 LAUNCHER_AUTHORS = ["Théo Rozier <contact@theorozier.fr>", "Contributors"]
 LAUNCHER_COPYRIGHT = "PortableMC  Copyright (C) 2021-2024  Théo Rozier"
 LAUNCHER_URL = "https://github.com/mindstorm38/portablemc"

--- a/portablemc/auth.py
+++ b/portablemc/auth.py
@@ -288,8 +288,8 @@ class MicrosoftAuthSession(AuthSession):
         # Microsoft OAuth
         try:
             res = cls.ms_request("https://login.live.com/oauth20_token.srf", request_token_payload, payload_url_encoded=True)
-        except HttpError:
-            raise OutdatedTokenError()
+        except HttpError as error:
+            raise OutdatedTokenError(error.res.text())
 
         ms_refresh_token = res.get("refresh_token")
 
@@ -332,9 +332,9 @@ class MicrosoftAuthSession(AuthSession):
             res = cls.mc_request_profile(mc_access_token)
         except HttpError as error:
             if error.res.status == 404:
-                raise DoesNotOwnMinecraftError()
+                raise DoesNotOwnMinecraftError(error.res.text())
             elif error.res.status == 401:
-                raise OutdatedTokenError()
+                raise OutdatedTokenError(error.res.text())
             else:
                 res = error.res.json()
                 raise AuthError(res.get("errorMessage", res.get("error", "unknown error")))
@@ -465,9 +465,9 @@ class AuthError(Exception):
     pass
 
 class DoesNotOwnMinecraftError(AuthError):
-    def __init__(self) -> None:
-        super().__init__("does not own minecraft")
+    def __init__(self, *args) -> None:
+        super().__init__("does not own minecraft", *args)
 
 class OutdatedTokenError(AuthError):
-    def __init__(self) -> None:
-        super().__init__("outdated token")
+    def __init__(self, *args) -> None:
+        super().__init__("outdated token", *args)

--- a/portablemc/auth.py
+++ b/portablemc/auth.py
@@ -337,7 +337,7 @@ class MicrosoftAuthSession(AuthSession):
                 raise OutdatedTokenError()
             else:
                 res = error.res.json()
-                raise AuthError(res.get("errorMessage", res.get("error", "Unknown error")))
+                raise AuthError(res.get("errorMessage", res.get("error", "unknown error")))
 
         return {
             "refresh_token": ms_refresh_token,
@@ -465,7 +465,9 @@ class AuthError(Exception):
     pass
 
 class DoesNotOwnMinecraftError(AuthError):
-    pass
+    def __init__(self) -> None:
+        super().__init__("does not own minecraft")
 
 class OutdatedTokenError(AuthError):
-    pass
+    def __init__(self) -> None:
+        super().__init__("outdated token")

--- a/portablemc/cli/__init__.py
+++ b/portablemc/cli/__init__.py
@@ -273,14 +273,19 @@ def cmd_search_handler(ns: SearchNs, kind: str, table: OutputTable):
             if search is None or search in alias:
                 table.add(alias, version)
 
-    elif kind in ("fabric", "quilt"):
+    elif kind in ("fabric", "quilt", "legacyfabric"):
 
-        from ..fabric import FABRIC_API, QUILT_API
+        from ..fabric import FABRIC_API, QUILT_API, LEGACYFABRIC_API
 
         table.add(_("search.loader_version"))
         table.separator()
 
-        api = FABRIC_API if kind == "fabric" else QUILT_API
+        if kind == "fabric":
+            api = FABRIC_API()
+        elif kind == "quilt":
+            api = QUILT_API()
+        else:
+            api = LEGACYFABRIC_API()
         for version in api.request_fabric_loader_versions():
             if search is None or search in version:
                 table.add(version)
@@ -445,10 +450,15 @@ def cmd_start_handler(ns: StartNs, kind: str, parts: List[str]) -> Optional[Vers
             return None
         return Version(version, context=ns.context)
     
-    elif kind in ("fabric", "quilt"):
+    elif kind in ("fabric", "quilt", "legacyfabric"):
         if len(parts) > 2:
             return None
-        constructor = FabricVersion.with_fabric if kind == "fabric" else FabricVersion.with_quilt
+        if kind == "fabric":
+            constructor = FabricVersion.with_fabric
+        elif kind == "quilt":
+            constructor = FabricVersion.with_quilt
+        else:
+            constructor = FabricVersion._with_legacyfabric
         prefix = ns.fabric_prefix if kind == "fabric" else ns.quilt_prefix
         if len(parts) != 2:
             ns.socket_error_tips.append(f"{kind}_loader_version")

--- a/portablemc/cli/__init__.py
+++ b/portablemc/cli/__init__.py
@@ -464,6 +464,11 @@ def cmd_start_handler(ns: StartNs, kind: str, parts: List[str]) -> Optional[Vers
         if len(parts) > 2:
             return None
         
+        # Legacy fabric has a special case because it will never be supported for 
+        # versions past 1.12.2, it is not made for latest release version.
+        if kind == "legacyfabric" and version == "release":
+            version = "1.12.2"
+        
         if kind == "fabric":
             constructor = FabricVersion.with_fabric
             prefix = ns.fabric_prefix

--- a/portablemc/cli/__init__.py
+++ b/portablemc/cli/__init__.py
@@ -277,18 +277,19 @@ def cmd_search_handler(ns: SearchNs, kind: str, table: OutputTable):
 
         from ..fabric import FABRIC_API, QUILT_API, LEGACYFABRIC_API
 
-        table.add(_("search.loader_version"))
+        table.add(_("search.loader_version"), _("search.flags"))
         table.separator()
 
         if kind == "fabric":
-            api = FABRIC_API()
+            api = FABRIC_API
         elif kind == "quilt":
-            api = QUILT_API()
+            api = QUILT_API
         else:
-            api = LEGACYFABRIC_API()
-        for version in api.request_fabric_loader_versions():
-            if search is None or search in version:
-                table.add(version)
+            api = LEGACYFABRIC_API
+        
+        for loader in api.request_loaders():
+            if search is None or search in loader.version:
+                table.add(loader.version, _("search.flags.stable") if loader.stable else "")
 
     else:
         raise ValueError()

--- a/portablemc/cli/__init__.py
+++ b/portablemc/cli/__init__.py
@@ -11,6 +11,7 @@ from subprocess import Popen
 from pathlib import Path
 import socket
 import sys
+import io
 
 from .parse import register_arguments, RootNs, SearchNs, StartNs, LoginNs, LogoutNs, AuthBaseNs, ShowCompletionNs
 
@@ -66,6 +67,13 @@ def main(args: Optional[List[str]] = None):
     find a command handler to dispatch to. These command handlers are specified by the
     `get_command_handlers` function.
     """
+
+    # Force stdout/stderr to use UTF-8 encoding, this reconfigure method 
+    # is available for Python 3.7 and onward.
+    if isinstance(sys.stdout, io.TextIOWrapper):
+        sys.stdout.reconfigure(encoding='utf-8')
+    if isinstance(sys.stderr, io.TextIOWrapper):
+        sys.stderr.reconfigure(encoding='utf-8')
 
     parser = register_arguments()
     ns: RootNs = cast(RootNs, parser.parse_args(args or sys.argv[1:]))

--- a/portablemc/cli/__init__.py
+++ b/portablemc/cli/__init__.py
@@ -287,7 +287,7 @@ def cmd_search_handler(ns: SearchNs, kind: str, table: OutputTable):
         else:
             api = LEGACYFABRIC_API
         
-        for loader in api.request_loaders():
+        for loader in api._request_loaders():
             if search is None or search in loader.version:
                 table.add(loader.version, _("search.flags.stable") if loader.stable else "")
 
@@ -452,17 +452,23 @@ def cmd_start_handler(ns: StartNs, kind: str, parts: List[str]) -> Optional[Vers
         return Version(version, context=ns.context)
     
     elif kind in ("fabric", "quilt", "legacyfabric"):
+
         if len(parts) > 2:
             return None
+        
         if kind == "fabric":
             constructor = FabricVersion.with_fabric
+            prefix = ns.fabric_prefix
         elif kind == "quilt":
             constructor = FabricVersion.with_quilt
+            prefix = ns.quilt_prefix
         else:
             constructor = FabricVersion._with_legacyfabric
-        prefix = ns.fabric_prefix if kind == "fabric" else ns.quilt_prefix
+            prefix = ns.legacyfabric_prefix
+        
         if len(parts) != 2:
             ns.socket_error_tips.append(f"{kind}_loader_version")
+
         return constructor(version, parts[1] if len(parts) == 2 else None, context=ns.context, prefix=prefix)
     
     elif kind in ("forge", "neoforge"):

--- a/portablemc/cli/lang.py
+++ b/portablemc/cli/lang.py
@@ -89,7 +89,7 @@ lang = {
     "args.start.version.comp.release": "Start the latest release (default).",
     "args.start.version.comp.snapshot": "Start the latest snapshot.",
     "args.start.version.comp.fabric": "Start Fabric mod loader with latest release.",
-    "args.start.version.comp.legacyfabric": "Start (Legacy)Fabric mod loader with latest release.",
+    "args.start.version.comp.legacyfabric": "Start LegacyFabric mod loader with latest release.",
     "args.start.version.comp.quilt": "Start Quilt mod loader with latest release.",
     "args.start.version.comp.forge": "Start Forge mod loader with latest release.",
     "args.start.version.comp.neoforge": "Start NeoForge mod loader with latest release.",

--- a/portablemc/cli/lang.py
+++ b/portablemc/cli/lang.py
@@ -37,8 +37,8 @@ lang = {
     "args._": 
         "  A fast, reliable and cross-platform command-line Minecraft launcher and API\n"
         "  for developers. Including fast and easy installation of common mod loaders such\n"
-        "  as Fabric, LegacyFabric, Forge, NeoForge and Quilt. This launcher is compatible with the\n"
-        "  standard Minecraft directories.\n\n",
+        "  as Fabric, LegacyFabric, Forge, NeoForge and Quilt. This launcher is compatible\n" 
+        "  with the standard Minecraft directories.\n\n",
     "args.main_dir": "Set the main directory where libraries, assets and versions.",
     "args.work_dir": "Set the working directory where the game run and place for examples "
         "saves, screenshots (and resources for legacy versions), it also store "
@@ -89,7 +89,7 @@ lang = {
     "args.start.version.comp.release": "Start the latest release (default).",
     "args.start.version.comp.snapshot": "Start the latest snapshot.",
     "args.start.version.comp.fabric": "Start Fabric mod loader with latest release.",
-    "args.start.version.comp.legacyfabric": "Start (legacy) Fabric mod loader with latest release.",
+    "args.start.version.comp.legacyfabric": "Start (Legacy)Fabric mod loader with latest release.",
     "args.start.version.comp.quilt": "Start Quilt mod loader with latest release.",
     "args.start.version.comp.forge": "Start Forge mod loader with latest release.",
     "args.start.version.comp.neoforge": "Start NeoForge mod loader with latest release.",
@@ -182,6 +182,7 @@ lang = {
     "search.last_modified": "Last modified",
     "search.flags": "Flags",
     "search.flags.local": "local",
+    "search.flags.stable": "stable",
     "search.loader_version": "Loader version",
     # Command login
     "login.tip.remember_start_login": "Remember to start the game with '-l {email}' if you want to be authenticated in-game.",

--- a/portablemc/cli/lang.py
+++ b/portablemc/cli/lang.py
@@ -89,7 +89,7 @@ lang = {
     "args.start.version.comp.release": "Start the latest release (default).",
     "args.start.version.comp.snapshot": "Start the latest snapshot.",
     "args.start.version.comp.fabric": "Start Fabric mod loader with latest release.",
-    "args.start.version.comp.legacyfabric": "Start LegacyFabric mod loader with latest release.",
+    "args.start.version.comp.legacyfabric": "Start (legacy) Fabric mod loader with latest release.",
     "args.start.version.comp.quilt": "Start Quilt mod loader with latest release.",
     "args.start.version.comp.forge": "Start Forge mod loader with latest release.",
     "args.start.version.comp.neoforge": "Start NeoForge mod loader with latest release.",

--- a/portablemc/cli/lang.py
+++ b/portablemc/cli/lang.py
@@ -192,6 +192,7 @@ lang = {
     "logout.success": "Logged out {email}",
     "logout.unknown_session": "No session for {email}",
     # Command start
+    "start.global_version": "Global version: {kind} {version} {remaining}",
     "start.version.invalid_id": "Invalid version id, expected: {expected}",
     "start.version.invalid_id_unknown_kind": "Invalid version id, unknown kind: {kind}.",
     "start.version.loading": "Loading version {version}... ",
@@ -200,7 +201,7 @@ lang = {
     "start.version.loaded.fetched": "Loaded version {version} (fetched)",
     "start.version.not_found": "Version {version} not found",
     "start.version.too_much_parents": "Too much parents while resolving versions.",
-    "start.features": "Features: {features}",
+    "start.features": "Features: [{features}]",
     "start.jar.found": "Checked version jar",
     "start.jar.not_found": "Version jar not found",
     "start.assets.resolving": "Checking assets version {index_version}... ",
@@ -223,7 +224,6 @@ lang = {
         "use --jvm argument to manually set the path to your JVM executable.",
     f"start.jvm.not_found_error.{JvmNotFoundError.BUILTIN_INVALID_VERSION}": f"The builtin JVM ({jvm_bin_filename}) is not compatible "
         "with selected game version.",
-    "start.fixes": "Applied the following fixes:",
     f"start.fix.{Version.FIX_LEGACY_PROXY}": "Using legacy proxy for online resources: {value}",
     f"start.fix.{Version.FIX_LEGACY_MERGE_SORT}": "Using legacy merge sort: {value}",
     f"start.fix.{Version.FIX_LEGACY_RESOLUTION}": "Included resolution into game arguments: {value}",

--- a/portablemc/cli/lang.py
+++ b/portablemc/cli/lang.py
@@ -37,7 +37,7 @@ lang = {
     "args._": 
         "  A fast, reliable and cross-platform command-line Minecraft launcher and API\n"
         "  for developers. Including fast and easy installation of common mod loaders such\n"
-        "  as Fabric, Forge, NeoForge and Quilt. This launcher is compatible with the\n"
+        "  as Fabric, LegacyFabric, Forge, NeoForge and Quilt. This launcher is compatible with the\n"
         "  standard Minecraft directories.\n\n",
     "args.main_dir": "Set the main directory where libraries, assets and versions.",
     "args.work_dir": "Set the working directory where the game run and place for examples "
@@ -72,6 +72,7 @@ lang = {
     "args.search.kind.comp.local": "Search for locally installed versions.",
     "args.search.kind.comp.forge": "Search for Forge versions.",
     "args.search.kind.comp.fabric": "Search for Fabric versions.",
+    "args.search.kind.comp.legacyfabric": "Search for LegacyFabric versions.",
     "args.search.kind.comp.quilt": "Search for Quilt versions.",
     "args.search.input": "Search input.",
     "args.search.input.comp.release": "Resolve version of the latest release.",
@@ -81,12 +82,14 @@ lang = {
     "args.start.version": "Version identifier (default to release): {formats}.",
     "args.start.version.standard": "release|snapshot|<vanilla-version>",
     "args.start.version.fabric": "fabric:[<vanilla-version>[:<loader-version>]]",
+    "args.start.version.legacyfabric": "legacyfabric:[<vanilla-version>[:<loader-version>]]",
     "args.start.version.quilt": "quilt:[<vanilla-version>[:<loader-version>]]",
     "args.start.version.forge": "forge:[<forge-version>] (forge-version >= 1.5.2)",
     "args.start.version.neoforge": "neoforge:[<neoforge-version>] (neoforge-version >= 1.20.1)",
     "args.start.version.comp.release": "Start the latest release (default).",
     "args.start.version.comp.snapshot": "Start the latest snapshot.",
     "args.start.version.comp.fabric": "Start Fabric mod loader with latest release.",
+    "args.start.version.comp.legacyfabric": "Start LegacyFabric mod loader with latest release.",
     "args.start.version.comp.quilt": "Start Quilt mod loader with latest release.",
     "args.start.version.comp.forge": "Start Forge mod loader with latest release.",
     "args.start.version.comp.neoforge": "Start NeoForge mod loader with latest release.",
@@ -102,6 +105,7 @@ lang = {
     "args.start.no_fix": "Flag that globally disable fixes (proxy for old versions), "
         "enabled by default.",
     "args.start.fabric_prefix": "Change the prefix of the version ID when starting with Fabric (<prefix>-<vanilla-version>-<loader-version>).",
+    "args.start.legacyfabric_prefix": "Change the prefix of the version ID when starting with LegacyFabric (<prefix>-<vanilla-version>-<loader-version>).",
     "args.start.quilt_prefix": "Change the prefix of the version ID when starting with Quilt (<prefix>-<vanilla-version>-<loader-version>).",
     "args.start.forge_prefix": "Change the prefix of the version ID when starting with Forge (<prefix>-<forge-version>).",
     "args.start.neoforge_prefix": "Change the prefix of the version ID when starting with NeoForge (<prefix>-<neoforge-version>).",
@@ -168,6 +172,7 @@ lang = {
     "error.socket": "This operation requires an operational network, but a socket error happened:",
     "error.socket.tip.version_manifest": "Version manifest may not be locally cached, try to run this command once with an operational network.",
     "error.socket.tip.fabric_loader_version": "Fabric loader version must be specified if network is not operational.",
+    "error.socket.tip.legacyfabric_loader_version": "Fabric loader version must be specified if network is not operational.",
     "error.socket.tip.quilt_loader_version": "Quilt loader version must be specified if network is not operational.",
     "error.cert": "Certificate verification failed, you can try installing 'certifi' package:",
     # Command search

--- a/portablemc/cli/output.py
+++ b/portablemc/cli/output.py
@@ -175,10 +175,10 @@ class HumanOutput(Output):
                     break
             
             if chosen_color is not None:
-                print(chosen_color, text, "\033[0m", sep="", end="")
+                print(chosen_color, text, "\033[0m", sep="", end="", flush=True)
                 return
         
-        print(text, end="")
+        print(text, end="", flush=True)
     
     def prompt(self, password: bool = False) -> Optional[str]:
         try:
@@ -247,7 +247,7 @@ class HumanTable(OutputTable):
                 
                 print(format_string.format(*format_columns), flush=False)
         
-        print("└─{}─┘".format("─┴─".join(columns_lines)))
+        print("└─{}─┘".format("─┴─".join(columns_lines)), flush=True)
 
 
 class MachineOutput(Output):

--- a/portablemc/cli/parse.py
+++ b/portablemc/cli/parse.py
@@ -215,7 +215,7 @@ def get_outputs() -> List[str]:
     return ["human-color", "human", "machine"]
 
 def get_search_kinds() -> List[str]:
-    return ["mojang", "local", "forge", "fabric", "quilt"]
+    return ["mojang", "local", "forge", "fabric", "quilt", "legacyfabric"]
 
 def get_auth_services() -> List[str]:
     return ["microsoft", "yggdrasil"]

--- a/portablemc/cli/parse.py
+++ b/portablemc/cli/parse.py
@@ -48,6 +48,7 @@ class StartNs(AuthBaseNs):
     jvm_args: Optional[str]
     no_fix: bool
     fabric_prefix: str
+    legacyfabric_prefix: str
     quilt_prefix: str
     forge_prefix: str
     neoforge_prefix: str

--- a/portablemc/cli/parse.py
+++ b/portablemc/cli/parse.py
@@ -145,6 +145,7 @@ def register_start_arguments(parser: ArgumentParser) -> None:
     parser.add_argument("--no-fix", help=_("args.start.no_fix"), action="store_true")
     parser.add_argument("--fabric-prefix", help=_("args.start.fabric_prefix"), default="fabric", metavar="PREFIX")
     parser.add_argument("--quilt-prefix", help=_("args.start.quilt_prefix"), default="quilt", metavar="PREFIX")
+    parser.add_argument("--legacyfabric-prefix", help=_("args.start.legacyfabric_prefix"), default="legacyfabric", metavar="PREFIX")
     parser.add_argument("--forge-prefix", help=_("args.start.forge_prefix"), default="forge", metavar="PREFIX")
     parser.add_argument("--neoforge-prefix", help=_("args.start.neoforge_prefix"), default="neoforge", metavar="PREFIX")
     parser.add_argument("--lwjgl", help=_("args.start.lwjgl"))
@@ -159,10 +160,10 @@ def register_start_arguments(parser: ArgumentParser) -> None:
     parser.add_argument("-s", "--server", help=_("args.start.server"), type=type_host)
     parser.add_argument("-p", "--server-port", help=_("args.start.server_port"), metavar="PORT")
 
-    version_arg = parser.add_argument("version", nargs="?", default="release", help=_("args.start.version", formats=", ".join(map(lambda s: _(f"args.start.version.{s}"), ("standard", "fabric", "quilt", "forge", "neoforge")))))
+    version_arg = parser.add_argument("version", nargs="?", default="release", help=_("args.start.version", formats=", ".join(map(lambda s: _(f"args.start.version.{s}"), ("standard", "fabric", "quilt", "legacyfabric", "forge", "neoforge")))))
     for standard in ("release", "snapshot"):
         add_completion(version_arg, standard, _(f"args.start.version.comp.{standard}"))
-    for loader in ("fabric", "quilt", "forge", "neoforge"):
+    for loader in ("fabric", "quilt", "legacyfabric", "forge", "neoforge"):
         add_completion(version_arg, f"{loader}:", _(f"args.start.version.comp.{loader}"))
 
 

--- a/portablemc/download.py
+++ b/portablemc/download.py
@@ -330,17 +330,18 @@ def _download_thread(
                         pass
 
                     if res.status == 301 or res.status == 302:
-
-                        redirect_url = res.headers["location"]
-                        redirect_entry = DownloadEntry(
-                            redirect_url, 
-                            entry.dst, 
-                            size=entry.size, 
-                            sha1=entry.sha1, 
-                            name=entry.name)
-                        
-                        entries_queue.put(_DownloadEntry.from_entry(redirect_entry))
-                        break  # Abort on redirect
+                        # If location header is absent, consider it not found.
+                        redirect_url = res.headers.get("location")
+                        if redirect_url is not None:
+                            redirect_entry = DownloadEntry(
+                                redirect_url, 
+                                entry.dst, 
+                                size=entry.size, 
+                                sha1=entry.sha1, 
+                                name=entry.name)
+                            
+                            entries_queue.put(_DownloadEntry.from_entry(redirect_entry))
+                            break  # Abort on redirect
 
                     # Any other non-200 code is considered not found and we retry...
                     last_error = DownloadResultError.NOT_FOUND

--- a/portablemc/fabric.py
+++ b/portablemc/fabric.py
@@ -36,7 +36,20 @@ class FabricApi:
 
 FABRIC_API = FabricApi("fabric", "https://meta.fabricmc.net/v2/")
 QUILT_API = FabricApi("quilt", "https://meta.quiltmc.org/v3/")
-
+LEGACYFABRIC_API = FabricApi("legacyfabric", "https://meta.legacyfabric.net/v2/")
+LEGACYFABRIC_VERSIONS = [
+    "1.13.2",
+    "1.12.2",
+    "1.11.2",
+    "1.10.2",
+    "1.9.4",
+    "1.8.9",
+    "1.7.10",
+    "1.6.4",
+    "1.5.2",
+    "1.4.7",
+    "1.3.2"
+]
 
 class FabricVersion(Version):
 
@@ -59,7 +72,8 @@ class FabricVersion(Version):
     ) -> "FabricVersion":
         """Construct a root for resolving a Fabric version.
         """
-        return cls(FABRIC_API, vanilla_version, loader_version, prefix, context=context)
+        return cls(FABRIC_API if vanilla_version not in LEGACYFABRIC_VERSIONS else LEGACYFABRIC_API,
+                   vanilla_version, loader_version, prefix, context=context)
 
     @classmethod
     def with_quilt(cls, vanilla_version: str = "release", loader_version: Optional[str] = None, *,

--- a/portablemc/fabric.py
+++ b/portablemc/fabric.py
@@ -42,9 +42,9 @@ LEGACYFABRIC_API = FabricApi("legacyfabric", "https://meta.legacyfabric.net/v2/"
 class FabricVersion(Version):
 
     def __init__(self, api: FabricApi, vanilla_version: str, loader_version: Optional[str],
-                 prefix: str, *,
-                 context: Optional[Context] = None,
-                 ) -> None:
+        prefix: str, *,
+        context: Optional[Context] = None,
+    ) -> None:
 
         super().__init__("", context=context)  # Do not give a root version for now.
 
@@ -55,18 +55,18 @@ class FabricVersion(Version):
 
     @classmethod
     def with_fabric(cls, vanilla_version: str = "release", loader_version: Optional[str] = None, *,
-                    context: Optional[Context] = None,
-                    prefix: str = "fabric"
-                    ) -> "FabricVersion":
+        context: Optional[Context] = None,
+        prefix: str = "fabric"
+    ) -> "FabricVersion":
         """Construct a root for resolving a Fabric version.
         """
         return cls(FABRIC_API, vanilla_version, loader_version, prefix, context=context)
 
     @classmethod
     def with_quilt(cls, vanilla_version: str = "release", loader_version: Optional[str] = None, *,
-                   context: Optional[Context] = None,
-                   prefix: str = "quilt"
-                   ) -> "FabricVersion":
+        context: Optional[Context] = None,
+        prefix: str = "quilt"
+    ) -> "FabricVersion":
         """Construct a root for resolving a Quilt version.
         """
         return cls(QUILT_API, vanilla_version, loader_version, prefix, context=context)
@@ -134,7 +134,6 @@ class FabricResolveEvent:
     """Event triggered when the loader version is missing and is being resolved.
     """
     __slots__ = "api", "vanilla_version", "loader_version"
-
     def __init__(self, api: FabricApi, vanilla_version: str, loader_version: Optional[str]) -> None:
         self.api = api
         self.vanilla_version = vanilla_version

--- a/portablemc/standard.py
+++ b/portablemc/standard.py
@@ -1622,14 +1622,14 @@ class StreamRunner(StandardRunner):
         stdout = process.stdout
         assert stdout is not None, "should not be none because it should be piped"
 
-        parser = None
+        parser = StreamParser()
         for line in iter(stdout.readline, ""):
 
-            if parser is None:
-                if line.lstrip().startswith("<log4j:"):
-                    parser = XmlStreamParser()
-                else:
-                    parser = StreamParser()
+            # By default the parser is raw but if we encounter any potential XML tag we
+            # set the parser to the XML one and starting parsing. If it fails immediately
+            # then it reset it to a raw stream parser.
+            if line.lstrip().startswith("<log4j:") and not isinstance(parser, XmlStreamParser):
+                parser = XmlStreamParser()
 
             if not parser.feed(line, self.process_stream_event):
                 parser = StreamParser()

--- a/portablemc/standard.py
+++ b/portablemc/standard.py
@@ -1561,17 +1561,20 @@ class StandardRunner(Runner):
                 *replace_list_vars(env.game_args, replacements)
             ], env.context.work_dir)
 
-            self.process_wait(process)
+            if process is not None:
+                self.process_wait(process)
 
         finally:
             # Any error while setting up the binary directory cause it to be deleted.
             shutil.rmtree(bin_dir, ignore_errors=True)
 
-    def process_create(self, args: List[str], work_dir: Path) -> Popen:
+    def process_create(self, args: List[str], work_dir: Path) -> Optional[Popen]:
         """This function is called when process needs to be created with the given 
         arguments in the given working directory. The default implementation does nothing
         special but this can be used to create the process with enabled output piping,
         to later use in `process_wait`.
+
+        None can be returned to abort starting the game.
         """
         return Popen(args, cwd=work_dir)
 
@@ -1597,7 +1600,7 @@ class StreamRunner(StandardRunner):
     its completion.
     """
     
-    def process_create(self, args: List[str], work_dir: Path) -> Popen:
+    def process_create(self, args: List[str], work_dir: Path) -> Optional[Popen]:
         return Popen(args, cwd=work_dir, stdout=PIPE, stderr=STDOUT, bufsize=1, universal_newlines=True, encoding="utf-8", errors="replace")
 
     def process_wait(self, process: Popen) -> None:

--- a/portablemc/standard.py
+++ b/portablemc/standard.py
@@ -1591,10 +1591,10 @@ class StandardRunner(Runner):
 
 
 class StreamRunner(StandardRunner):
-    """A specialized implementation of `RunTask` which allows streaming the game's output
-    logs. This implementation also provides parsing of log4j XML layouts for logs. This
-    runner handles KeyboardInterrupt errors and properly kill the game and waits for it
-    completion.
+    """A specialized implementation of `StandardRunner` which allows streaming the game's 
+    output logs. This implementation also provides parsing of log4j XML layouts for logs. 
+    This runner handles KeyboardInterrupt errors and properly kill the game and waits for 
+    its completion.
     """
     
     def process_create(self, args: List[str], work_dir: Path) -> Popen:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "portablemc"
-version = "4.2.1"
+version = "4.3.0"
 description = "PortableMC is a module that provides both an API for development of your custom launcher and an executable script to run PortableMC CLI."
 authors = ["Théo Rozier <contact@theorozier.fr>"]
 license = "GPL-3.0-only"


### PR DESCRIPTION
### Changes
- *CLI*: Improved authentication error messages (#199)
- *CLI*: Added support for starting and searching legacyfabric (#205, thanks @BluCobalt)
- *CLI*: Fixed an issue with stdout/stderr where encoding was not UTF-8 and therefore crashes the launcher in some case, reported on Windows (#210, thanks @marewey)
- *CLI*: Running the game in dry mode now build the command line, that can be shown using `-vv` verbosity flag
- *API*: Added support for "legacyfabric" fabric *unstable* API (#205, thanks @BluCobalt)
- *API*: Automatic XML log detection has been improved (#209)
- *API*: Fixed a potential bug for invalid HTTP response when batch downloading