### PR TITLE
Use migrated Minecraft wiki link now

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ by the LWJGL-provided natives).
 #### Miscellaneous
 With `--dry`, the start command does not start the game, but simply installs it.
 
-With `--demo` you can enable the [demo mode](https://minecraft.gamepedia.com/Demo_mode) 
+With `--demo` you can enable the [demo mode](https://minecraft.wiki/w/Demo_mode) 
 of the game.  
 
 With `--resolution <width>x<height>` you can change the resolution of the game window.

--- a/portablemc/standard.py
+++ b/portablemc/standard.py
@@ -49,7 +49,7 @@ class Context:
 
         :param main_dir: The main directory where versions, assets, libraries and 
         optionally JVM are installed. If not specified this path will be set the usual 
-        `.minecraft` (see https://minecraft.fandom.com/fr/wiki/.minecraft).
+        `.minecraft` (see https://minecraft.wiki/w/.minecraft).
         :param work_dir: The working directory from where the game is run, the game stores
         thing like saves, resource packs, options and mods if relevant. This defaults to
         `main_dir` if not specified.


### PR DESCRIPTION
Minecraft wiki has already migrated from annoying Fandom for some time.
This PR is made to follow their initiatives about stopping the use of old Minecraft wiki link.