### PR TITLE
Patch 5.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,15 +1056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,15 +1262,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -1846,37 +1828,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1884,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1896,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2453,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -2688,12 +2665,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ PortableMC project is: `f659b0f0b84a26cac635d72948caee8dc3456b2f`
 
 You can download the full PGP certificate online:
 - [Ubuntu Keyserver](https://keyserver.ubuntu.com/pks/lookup?search=F659+B0F0+B84A+26CA+C635+D729+48CA+EE8D+C345+6B2F&fingerprint=on&op=index)
-- [Maintainer server](https://www.theorozier.fr/assets/pgp/portablemc.asc)
+- [Maintainer server](https://theorozier.fr/assets/pgp/portablemc.asc.html)
 
 ### Cargo
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Portable Minecraft Launcher
+# PortableMC
 Cross platform command line utility for launching Minecraft quickly and reliably with 
 included support for Mojang versions and popular mod loaders. It is also available as 
 a Rust crate for developers ~~and bindings for C and Python~~ (yet to come).
@@ -12,6 +12,7 @@ a Rust crate for developers ~~and bindings for C and Python~~ (yet to come).
   - [Cargo](#cargo)
   - [Linux third-party packages](#linux-third-party-packages)
     - [Arch Linux](#arch-linux)
+- [Usage](#usage)
 - [Contribute](#contribute)
   - [Repositories](#repositories)
   - [Contributors](#contributors)
@@ -86,6 +87,32 @@ Arch Linux packages are maintained by PortableMC team.
 - Prebuilt binaries: [`portablemc-bin`](https://aur.archlinux.org/packages/portablemc-bin), available on AUR
 
 Prebuilt binaries requires you to install the PGP certificate, as described [above](#binaries).
+
+## Usage
+
+This section shows example usage to get started with PortableMC.
+
+```shell
+# Start the latest Mojang release, with a random username and default options...
+portablemc start
+
+# Start a specific version, let's say 1.16.5...
+portablemc start 1.16.5
+# You can list the Mojang versions...
+portablemc search
+# Search on the release versions, and limit to 10 entries...
+portablemc search --channel release -l10
+
+# Choose your username in offline mode...
+portablemc start -u MyUsername
+
+# Authenticate into your Minecraft account...
+portablemc auth login
+# List your authenticated accounts...
+portablemc auth list
+# Start the game with your authenticated account...
+portablemc start -u <your username> -a
+```
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ a Rust crate for developers ~~and bindings for C and Python~~ (yet to come).
 - [Installation](#installation)
   - [Binaries](#binaries)
   - [Cargo](#cargo)
-  - [Linux third-party packages](#linux-third-party-packages)
+  - [Linux packages](#linux-packages)
     - [Arch Linux](#arch-linux)
+    - [NixOS](#nixos)
 - [Usage](#usage)
 - [Contribute](#contribute)
   - [Repositories](#repositories)
@@ -72,10 +73,10 @@ launcher, it is also available on [crates.io](https://crates.io/crates/portablem
 cargo add portablemc
 ```
 
-### Linux third-party packages
+### Linux packages
 
 We try to deploy the package to different Linux packaging repositories, some are managed
-by maintainers of the project and some by external maintainers.
+by maintainers of the project (first-party) and some by external maintainers (third-party).
 
 #### Arch Linux
 
@@ -87,6 +88,10 @@ Arch Linux packages are maintained by PortableMC team.
 - Prebuilt binaries: [`portablemc-bin`](https://aur.archlinux.org/packages/portablemc-bin), available on AUR
 
 Prebuilt binaries requires you to install the PGP certificate, as described [above](#binaries).
+
+#### NixOS
+
+Nix package is maintained by @TomaSajt, at [`nixpkgs/portablemc`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/po/portablemc/package.nix).
 
 ## Usage
 

--- a/portablemc-cli/src/cmd/mod.rs
+++ b/portablemc-cli/src/cmd/mod.rs
@@ -8,7 +8,8 @@ mod r#gen;
 use std::process::{self, ExitCode};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
-use std::io;
+use std::{env, io};
+use std::fs;
 
 use portablemc::{base, download, moj, fabric, forge, msa};
 
@@ -648,8 +649,12 @@ pub fn log_base_error(cli: &mut Cli, error: &base::Error) {
                 .error(format_args!("Library {gav} not found and no download information is available"));
         }
         Error::JvmNotFound { major_version } => {
+            let os_id = os_id();
             let mut log = out.log("error_jvm_not_found");
             log.error(format_args!("No compatible JVM found for the game version, which requires major version {major_version}"));
+            if os_id.iter().any(|s| s == "debian") {
+                log.additional(format_args!("It appears that you run a Debian distribution, you could try 'apt install openjdk-{major_version}-jre'"));
+            }
             log.additional("You can enable verbose mode to learn more about potential JVM rejections");
             if *major_version <= 8 {
                 log.additional("Note that JVM version 8 and prior versions are not compatible with other versions");
@@ -1089,4 +1094,29 @@ fn forge_id_name(loader: forge::Loader) -> (&'static str, &'static str) {
         forge::Loader::Forge => ("forge", "Forge"),
         forge::Loader::NeoForge => ("neoforge", "NeoForge"),
     }
+}
+
+/// Internal function to get the current operating system distribution ID.
+///
+/// See: https://www.freedesktop.org/software/systemd/man/latest/os-release.html
+fn os_id() -> Vec<String> {
+    
+    if env::consts::FAMILY == "unix"
+    && let Ok(release) = fs::read_to_string("/etc/os-release") {
+        let mut ret = Vec::new();
+        for line in release.lines() {
+            let Some((k, v)) = line.split_once('=') else { continue };
+            match k {
+                "ID" => ret.insert(0, v.to_string()),
+                "ID_LIKE" => ret.extend(v.split(' ').map(str::to_string)),
+                _ => continue,
+            }
+        }
+        if !ret.is_empty() {
+            return ret;
+        }
+    }
+
+    vec![env::consts::OS.to_string()]
+
 }

--- a/portablemc-cli/src/cmd/mod.rs
+++ b/portablemc-cli/src/cmd/mod.rs
@@ -654,6 +654,8 @@ pub fn log_base_error(cli: &mut Cli, error: &base::Error) {
             log.error(format_args!("No compatible JVM found for the game version, which requires major version {major_version}"));
             if os_id.iter().any(|s| s == "debian") {
                 log.additional(format_args!("It appears that you run a Debian distribution, you could try 'apt install openjdk-{major_version}-jre'"));
+            } else if os_id.iter().any(|s| s == "arch") {
+                log.additional(format_args!("It appears that you run a Arch distribution, you could try 'pacman -Sy jre{major_version}-openjdk'"));
             }
             log.additional("You can enable verbose mode to learn more about potential JVM rejections");
             if *major_version <= 8 {

--- a/portablemc-cli/src/cmd/search.rs
+++ b/portablemc-cli/src/cmd/search.rs
@@ -70,7 +70,12 @@ fn search_mojang(cli: &mut Cli, args: &SearchArgs) -> ExitCode {
     });
 
     // Finally displaying version(s).
-    for version in manifest.iter().take(args.limit) {
+    let mut remaining = args.limit;
+    for version in manifest.iter() {
+
+        if remaining == 0 {
+            break;
+        }
 
         if let Some(only_name) = only_name {
             if version.name() != only_name {
@@ -92,6 +97,8 @@ fn search_mojang(cli: &mut Cli, args: &SearchArgs) -> ExitCode {
             }
 
         }
+
+        remaining -= 1;
         
         let mut row = table.row();
         row.cell(version.name());
@@ -157,7 +164,12 @@ fn search_local(cli: &mut Cli, args: &SearchArgs) -> ExitCode {
     
     table.sep();
 
-    for entry in reader.take(args.limit) {
+    let mut remaining = args.limit;
+    for entry in reader {
+
+        if remaining == 0 {
+            break;
+        }
         
         let Ok(entry) = entry else { continue };
         let Ok(entry_type) = entry.file_type() else { continue };
@@ -166,6 +178,8 @@ fn search_local(cli: &mut Cli, args: &SearchArgs) -> ExitCode {
         let mut version_dir = entry.path();
         let Some(version_id) = version_dir.file_name().unwrap().to_str() else { continue };
         let version_id = version_id.to_string();
+
+        remaining -= 1;
 
         version_dir.push(&version_id);
         version_dir.as_mut_os_string().push(".json");
@@ -216,8 +230,13 @@ fn search_fabric(cli: &mut Cli, args: &SearchArgs, loader: fabric::Loader, game:
         
         table.sep();
 
-        for version in versions.iter().take(args.limit) {
+        let mut remaining = args.limit;
+        for version in versions.iter() {
             
+            if remaining == 0 {
+                break;
+            }
+
             if !args.match_filter(version.name()) {
                 continue;
             }
@@ -225,6 +244,8 @@ fn search_fabric(cli: &mut Cli, args: &SearchArgs, loader: fabric::Loader, game:
             if !args.match_channel(SearchChannel::new_stable_or_unstable(version.is_stable())) {
                 continue;
             }
+
+            remaining -= 1;
 
             let mut row = table.row();
             row.cell(version.name());
@@ -253,7 +274,12 @@ fn search_fabric(cli: &mut Cli, args: &SearchArgs, loader: fabric::Loader, game:
         
         table.sep();
 
-        for version in versions.iter().take(args.limit) {
+        let mut remaining = args.limit;
+        for version in versions.iter() {
+            
+            if remaining == 0 {
+                break;
+            }
             
             if !args.match_filter(version.name()) {
                 continue;
@@ -262,6 +288,8 @@ fn search_fabric(cli: &mut Cli, args: &SearchArgs, loader: fabric::Loader, game:
             if !args.match_channel(SearchChannel::new_stable_or_unstable(version.is_stable())) {
                 continue;
             }
+
+            remaining -= 1;
 
             let mut row = table.row();
             row.cell(version.name());
@@ -304,8 +332,13 @@ fn search_forge(cli: &mut Cli, args: &SearchArgs, loader: forge::Loader) -> Exit
     // Forge .xml repositories are not sorted at all and therefore we have to sort them
     // here for the sorting to make sense to the user.
     let mut versions = Vec::new();
-    for version in repo.iter().take(args.limit) {
+    let mut remaining = args.limit;
+    for version in repo.iter() {
         
+        if remaining == 0 {
+            break;
+        }
+
         if !args.match_filter(version.name()) {
             continue;
         }
@@ -317,6 +350,8 @@ fn search_forge(cli: &mut Cli, args: &SearchArgs, loader: forge::Loader) -> Exit
         if !args.match_channel(SearchChannel::new_stable_or_unstable(version.is_stable())) {
             continue;
         }
+
+        remaining -= 1;
 
         versions.push(version);
         

--- a/portablemc-cli/src/cmd/start.rs
+++ b/portablemc-cli/src/cmd/start.rs
@@ -389,7 +389,8 @@ fn run_command(cli: &mut Cli, mut command: Command) -> io::Result<()> {
 
     cli.out.log("launched")
         .arg(child.id())
-        .success("Launched");
+        .success("Launched")
+        .info(format_args!("Process: {}", child.id()));
 
     // Take the stdout pipe and put the child in the shared location, only then we
     // release the guard so any handled Ctrl-C will terminate it.

--- a/portablemc-cli/src/parse.rs
+++ b/portablemc-cli/src/parse.rs
@@ -788,10 +788,6 @@ pub enum SearchLatestChannel {
 
 /// Manage the authentication sessions.
 /// 
-/// By default, this command will start a new authentication flow with the Microsoft
-/// authentication service, when completed this will add the newly authenticated session
-/// to the authentication database (specified with '--msa-db-file' argument).
-/// 
 /// If this command fails to load and/or store the database, its exit code is 1 (failure).
 #[derive(Debug, Args)]
 pub struct AuthArgs {

--- a/portablemc-cli/src/parse.rs
+++ b/portablemc-cli/src/parse.rs
@@ -291,7 +291,7 @@ pub struct StartArgs {
     /// where the game will check for natives to load. The main use case is for including
     /// shared objects (.so, .dll, .dylib), in case of versioned .so files like we can
     /// see on UNIX systems, the version is discarded when linked or copied to the bin
-    /// directory (/usr/lib/foo.so.1.22.2 -> foo.so).
+    /// directory (/usr/lib/foo.so.1.22.2 copied as foo.so).
     /// 
     /// Read the help message of '--exclude-lib' for a typical use case.
     /// 
@@ -304,11 +304,11 @@ pub struct StartArgs {
     /// This argument can be specified multiple times.
     #[arg(long, value_name = "PATH", display_order = ORDER_LIB)]
     pub include_class: Vec<PathBuf>,
-    /// The path to the JVM executable, 'java' (or 'javaw.exe' on Windows).
+    /// The path to the JVM executable, 'java' (or 'javaw.exe' on Windows) use to launch
+    /// the game.
     /// 
-    /// This is used to launch the game, it has a special use-case with Forge and NeoForge
-    /// loader versions where that JVM executable is also used to run the installer 
-    /// processors.
+    /// Note that with Forge and NeoForge mod loaders, that JVM executable is also used 
+    /// to run the installer processors.
     /// 
     /// Note that when this argument is specified, you cannot specify the '--jvm-policy'
     /// argument.
@@ -322,9 +322,9 @@ pub struct StartArgs {
     /// You can specify multiple arguments after the '--jvm-arg' option, using commas ',',
     /// for example 'start --jvm-arg=-Xms256m,-Xmx2048m'.
     /// 
-    /// Most of the time you should prefer using the '--jvm-arg=' form because JVM 
-    /// arguments also starts with a dash, which would be ambiguous if using 
-    /// '--jvm-arg -X...' (NOT WORKING) for example.
+    /// Most of the time you should prefer using the '--jvm-arg=' (with an EQUAL sign) 
+    /// form because JVM arguments also starts with a dash, which would be ambiguous if 
+    /// using '--jvm-arg -X...' (NOT WORKING) for example.
     #[arg(long, value_name = "ARG", value_delimiter(','), display_order = ORDER_JVM)]
     pub jvm_arg: Vec<String>,
     /// Automatically join the given singleplayer world after game has been launched.
@@ -520,9 +520,9 @@ impl FromStr for StartVersion {
 pub enum StartJvmPolicy {
     /// The installer will try to find a suitable JVM executable in the path, searching
     /// a `java` (or `javaw.exe` on Windows) executable. On operating systems where it's
-    /// supported, this will also check for known directories (on Arch for example).
+    /// supported, this will also check for known directories and registries.
     /// If the version needs a specific JVM major version, each candidate executable is 
-    /// checked and a warning is triggered to notify that the version is not suited.
+    /// checked and a warning is triggered to notify that the version is not suitable.
     /// The install fails if none of those versions is valid.
     System,
     /// The installer will try to find a suitable JVM to install from Mojang-provided

--- a/portablemc-py/Cargo.toml
+++ b/portablemc-py/Cargo.toml
@@ -16,7 +16,7 @@ portablemc.workspace = true
 
 uuid.workspace = true
 
-pyo3 = { version = "0.23.4", features = ["extension-module"] }
+pyo3 = { version = "0.28.3", features = ["extension-module"] }
 
 [lib]
 name = "portablemc_py"

--- a/portablemc/src/base/mod.rs
+++ b/portablemc/src/base/mod.rs
@@ -1169,6 +1169,7 @@ impl Installer {
                 16 => "java-runtime-alpha",
                 17 => "java-runtime-gamma",
                 21 => "java-runtime-delta",
+                25 => "java-runtime-epsilon",
                 _ => return None
             }));
         

--- a/portablemc/src/moj/mod.rs
+++ b/portablemc/src/moj/mod.rs
@@ -1112,12 +1112,29 @@ impl InternalHandler<'_> {
     
     fn apply_fix_lwjgl(&mut self, libraries: &mut Vec<LoadedLibrary>, version: &str) -> Result<()> {
     
-        if version != "3.2.3" && !version.starts_with("3.3.") {
+        let Some(("", minor_patch)) = version.split_once("3.") else {
             return Err(Error::LwjglFixNotFound { 
                 version: version.to_string(),
             });
+        };
+
+        if minor_patch != "2.3" {
+            
+            let (minor, _) = minor_patch.split_once('.').unwrap_or((minor_patch, ""));
+            let Ok(minor) = minor.parse::<u32>() else {
+                return Err(Error::LwjglFixNotFound { 
+                    version: version.to_string(),
+                });
+            };
+
+            if minor < 3 {
+                return Err(Error::LwjglFixNotFound { 
+                    version: version.to_string(),
+                });
+            }
+
         }
-    
+        
         let classifier = match (env::consts::OS, env::consts::ARCH) {
             ("windows", "x86") => "natives-windows-x86",
             ("windows", "x86_64") => "natives-windows",


### PR DESCRIPTION
- *API*: Fixed lwjgl fix for LWJGL version 3.4 and onward, which were not supported because of a bad implementation
- *API*: Support for guessing java-runtime-epsilon (this was not needed for Mojang versions anyway)
- *CLI*: Added suggestion for installing Debian/Arch system-wide JVM packages when no compatible JVM is found
- *CLI*: Removed deprecated help message for old syntax, and various help improvements
- *CLI*: Fixed implementation of search limit, which was not respected when filtering
- *CLI*: Add debug line to show the process ID
- *Doc*: Added partial usage example in README (related to #275)
- *Internal*: Updated pyO3 version so that we no longer get errors while developing (note that Python binding is not yet ready)